### PR TITLE
Execute a models associate method if available.

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -15,5 +15,11 @@ module.exports = (sequelize, modelPath) => {
       }
     });
 
+  Object.keys(models).forEach(function(modelName) {
+    if (models[modelName].associate) {
+      models[modelName].associate(models);
+    }
+  });
+
   return models;
 };


### PR DESCRIPTION
This allows propper handling of associations between defined models. The implementation is in accordance with the skeleton structure generated by sequelize-cli. Models should thus be interchangeable between the two. This is unstested.
